### PR TITLE
Reuse unchanged atomic boxes

### DIFF
--- a/packages/core/src/Config.ts
+++ b/packages/core/src/Config.ts
@@ -7,6 +7,7 @@ import TextInlineRenderNode from './render/TextInlineRenderNode';
 import Box from './layout/Box';
 import ParagraphBlockBox from './layout/ParagraphBlockBox';
 import TextInlineBox from './layout/TextInlineBox';
+import TextAtomicBox from './layout/TextAtomicBox';
 import ViewNode from './view/ViewNode';
 import ParagraphBlockViewNode from './view/ParagraphBlockViewNode';
 import TextInlineViewNode from './view/TextInlineViewNode';
@@ -37,6 +38,7 @@ class Config {
     this.registerRenderNodeClass('Text', TextInlineRenderNode);
     this.registerBoxClass('ParagraphBlockRenderNode', ParagraphBlockBox);
     this.registerBoxClass('TextInlineRenderNode', TextInlineBox);
+    this.registerBoxClass('TextAtomicRenderNode', TextAtomicBox);
     this.registerViewNodeClass('ParagraphBlockBox', ParagraphBlockViewNode);
     this.registerViewNodeClass('TextInlineBox', TextInlineViewNode);
   }

--- a/packages/core/src/layout/AtomicBox.ts
+++ b/packages/core/src/layout/AtomicBox.ts
@@ -7,12 +7,22 @@ import InlineBox from './InlineBox';
 type Parent = InlineBox;
 
 export default abstract class AtomicBox extends Box {
+  protected version: number;
   protected parent?: Parent;
   protected breakable: boolean;
 
   constructor(renderNodeID: string) {
     super(renderNodeID);
+    this.version = 0;
     this.breakable = true;
+  }
+
+  setVersion(version: number) {
+    this.version = version;
+  }
+
+  getVersion(): number {
+    return this.version;
   }
 
   isBreakable(): boolean {

--- a/packages/core/src/layout/TextInlineBox.ts
+++ b/packages/core/src/layout/TextInlineBox.ts
@@ -1,25 +1,9 @@
-import TextInlineRenderNode from '../render/TextInlineRenderNode';
 import InlineBox from './InlineBox';
-import TextAtomicBox from './TextAtomicBox';
-import TextAtomicRenderNode from '../render/TextAtomicRenderNode';
 
 export default class TextInlineBox extends InlineBox {
 
   getType(): string {
     return 'TextInlineBox';
-  }
-
-  onRenderUpdated(renderNode: TextInlineRenderNode) {
-    super.onRenderUpdated(renderNode);
-    this.children = [];
-    renderNode.getChildren().forEach((child, childOffset) => {
-      if (!(child instanceof TextAtomicRenderNode)) {
-        throw new Error('Expecting child of TextInlineRenderNode to be AtomicInlineRenderNode.');
-      }
-      const textAtomicBox = new TextAtomicBox(child.getID());
-      this.insertChild(textAtomicBox, childOffset);
-      textAtomicBox.onRenderUpdated(child);
-    });
   }
 
   splitAt(offset: number): InlineBox {

--- a/packages/core/src/render/AtomicRenderNode.ts
+++ b/packages/core/src/render/AtomicRenderNode.ts
@@ -1,9 +1,10 @@
+import LeafNode from '../tree/LeafNode';
 import RenderNode from './RenderNode';
 import InlineRenderNode from './InlineRenderNode';
 
 export type Parent = InlineRenderNode;
 
-export default abstract class AtomicRenderNode extends RenderNode {
+export default abstract class AtomicRenderNode extends RenderNode implements LeafNode {
   protected version: number;
   protected parent: Parent;
 

--- a/packages/core/src/render/BlockRenderNode.ts
+++ b/packages/core/src/render/BlockRenderNode.ts
@@ -1,3 +1,4 @@
+import BranchNode from '../tree/BranchNode';
 import BlockElement from '../model/BlockElement';
 import RenderNode from './RenderNode';
 import DocRenderNode from './DocRenderNode';
@@ -6,7 +7,7 @@ import InlineRenderNode from './InlineRenderNode';
 export type Parent = DocRenderNode;
 export type Child = InlineRenderNode;
 
-export default abstract class BlockRenderNode extends RenderNode {
+export default abstract class BlockRenderNode extends RenderNode implements BranchNode {
   protected version: number;
   protected parent: Parent;
   protected selectableSize?: number;

--- a/packages/core/src/render/DocRenderNode.ts
+++ b/packages/core/src/render/DocRenderNode.ts
@@ -1,3 +1,4 @@
+import RootNode from '../tree/RootNode';
 import Doc from '../model/Doc';
 import RenderNode from './RenderNode';
 import BlockRenderNode from './BlockRenderNode';
@@ -6,7 +7,7 @@ export type Child = BlockRenderNode;
 
 type OnUpdatedSubscriber = () => void;
 
-export default class DocRenderNode extends RenderNode {
+export default class DocRenderNode extends RenderNode implements RootNode {
   protected version: number;
   protected selectableSize?: number;
   protected modelSize?: number;

--- a/packages/core/src/render/InlineRenderNode.ts
+++ b/packages/core/src/render/InlineRenderNode.ts
@@ -1,3 +1,4 @@
+import BranchNode from '../tree/BranchNode';
 import InlineElement from '../model/InlineElement';
 import RenderNode from './RenderNode';
 import BlockRenderNode from './BlockRenderNode';
@@ -6,7 +7,7 @@ import AtomicRenderNode from './AtomicRenderNode';
 export type Parent = BlockRenderNode;
 export type Child = AtomicRenderNode;
 
-export default abstract class InlineRenderNode extends RenderNode {
+export default abstract class InlineRenderNode extends RenderNode implements BranchNode {
   protected version: number;
   protected parent: Parent;
   protected selectableSize?: number;

--- a/packages/core/src/render/TextInlineRenderNode.ts
+++ b/packages/core/src/render/TextInlineRenderNode.ts
@@ -1,5 +1,6 @@
+import generateID from '../helpers/generateID';
 import Text from '../model/Text';
-import breakTextToWords from './helpers/breakTextToWords';
+import breakTextToWords, { Word } from './helpers/breakTextToWords';
 import InlineRenderNode from './InlineRenderNode';
 import TextAtomicRenderNode from './TextAtomicRenderNode';
 
@@ -9,13 +10,30 @@ export default class TextInlineRenderNode extends InlineRenderNode {
     return 'TextInlineRenderNode';
   }
 
-  onModelUpdated(node: Text) {
-    super.onModelUpdated(node);
-    this.children = [];
-    const words = breakTextToWords(node.getContent());
-    words.forEach((word, wordOffset) => {
-      const atomicRenderNode = new TextAtomicRenderNode(`${node.getID()}-${wordOffset}`, this, word.text, word.breakable);
-      this.children.push(atomicRenderNode);
+  onModelUpdated(element: Text) {
+    super.onModelUpdated(element);
+    const words = breakTextToWords(element.getContent());
+    let offset = 0;
+    words.forEach(word => {
+      let atomOffset = -1;
+      for (let n = offset, nn = this.children.length; n < nn; n++) {
+        const child = this.children[n] as TextAtomicRenderNode;
+        if (child.getContent() === word.text && child.getBreakable() === word.breakable) {
+          atomOffset = n;
+          break;
+        }
+      }
+      if (atomOffset < 0) {
+        const atomicRenderNode = new TextAtomicRenderNode(`${element.getID()}-${generateID()}`, this, word.text, word.breakable);
+        atomicRenderNode.setVersion(this.version + 1);
+        this.children.splice(offset, 0, atomicRenderNode);
+      } else {
+        this.children.splice(offset, atomOffset - offset);
+      }
+      offset++;
     });
+    if (offset < this.children.length) {
+      this.children.splice(offset, this.children.length - offset);
+    }
   }
 }

--- a/packages/core/src/render/helpers/breakTextToWords.ts
+++ b/packages/core/src/render/helpers/breakTextToWords.ts
@@ -4,7 +4,7 @@ const BREAKABLES = [
   '\t',
 ];
 
-interface Word {
+export interface Word {
   text: string;
   breakable: boolean;
 }


### PR DESCRIPTION
This reuses atomic boxes to avoid expensive recalculation of box width and height.

#2 
