### PR TITLE
Use tree interface

### DIFF
--- a/packages/core/src/layout/AtomicBox.ts
+++ b/packages/core/src/layout/AtomicBox.ts
@@ -7,22 +7,13 @@ import InlineBox from './InlineBox';
 type Parent = InlineBox;
 
 export default abstract class AtomicBox extends Box {
-  protected version: number;
-  protected parent?: Parent;
+  protected widthWithoutTrailingWhitespace?: number;
+  protected parent: Parent | null = null;
   protected breakable: boolean;
 
   constructor(renderNodeID: string) {
     super(renderNodeID);
-    this.version = 0;
     this.breakable = true;
-  }
-
-  setVersion(version: number) {
-    this.version = version;
-  }
-
-  getVersion(): number {
-    return this.version;
   }
 
   isBreakable(): boolean {
@@ -31,7 +22,7 @@ export default abstract class AtomicBox extends Box {
 
   abstract getWidthWithoutTrailingWhitespace(): number;
 
-  setParent(parent: Parent) {
+  setParent(parent: Parent | null) {
     this.parent = parent;
   }
 
@@ -88,4 +79,9 @@ export default abstract class AtomicBox extends Box {
   abstract resolveViewportPositionToSelectableOffset(x: number): number;
 
   abstract resolveSelectableOffsetRangeToViewportBoundingRects(from: number, to: number): ViewportBoundingRect[];
+
+  protected clearCache() {
+    super.clearCache();
+    this.widthWithoutTrailingWhitespace = undefined;
+  }
 }

--- a/packages/core/src/layout/BlockBox.ts
+++ b/packages/core/src/layout/BlockBox.ts
@@ -9,29 +9,16 @@ type Parent = PageFlowBox;
 type Child = LineFlowBox;
 
 export default abstract class BlockBox extends Box {
-  protected version: number;
-  protected width: number;
-  protected height?: number;
-  protected selectableSize?: number;
-  protected parent?: Parent;
-  protected children: Child[];
+  protected configWidth: number;
+  protected parent: Parent | null = null;
+  protected children: Child[] = [];
 
   constructor(renderNodeID: string) {
     super(renderNodeID);
-    this.version = 0;
-    this.width = 0;
-    this.children = [];
+    this.configWidth = 0;
   }
 
   abstract getType(): string;
-
-  setVersion(version: number) {
-    this.version = version;
-  }
-
-  getVersion(): number {
-    return this.version;
-  }
 
   getWidth(): number {
     return this.getParent().getInnerWidth();
@@ -48,7 +35,7 @@ export default abstract class BlockBox extends Box {
     return this.height;
   }
 
-  setParent(parent: Parent) {
+  setParent(parent: Parent | null) {
     this.parent = parent;
   }
 
@@ -59,9 +46,14 @@ export default abstract class BlockBox extends Box {
     return this.parent;
   }
 
-  insertChild(child: Child, offset: number) {
-    this.children.splice(offset, 0, child);
+  insertChild(child: Child, offset: number | null = null) {
     child.setParent(this);
+    if (offset === null) {
+      this.children.push(child);
+    } else {
+      this.children.splice(offset, 0, child);
+    }
+    this.clearCache();
   }
 
   deleteChild(child: Child) {
@@ -69,7 +61,9 @@ export default abstract class BlockBox extends Box {
     if (childOffset < 0) {
       throw new Error('Cannot delete child, child not found.');
     }
+    child.setParent(null);
     this.children.splice(childOffset, 1);
+    this.clearCache();
   }
 
   getChildren(): Child[] {
@@ -122,8 +116,7 @@ export default abstract class BlockBox extends Box {
   }
 
   onRenderUpdated(renderNode: BlockRenderNode) {
-    this.height = undefined;
-    this.selectableSize = undefined;
+    this.clearCache();
   }
 
   abstract splitAt(offset: number): BlockBox;

--- a/packages/core/src/layout/LayoutNode.ts
+++ b/packages/core/src/layout/LayoutNode.ts
@@ -1,12 +1,27 @@
-export default abstract class LayoutNode {
+import Node from '../tree/Node';
+
+export default abstract class LayoutNode implements Node {
   protected id: string;
+  protected version: number;
+  protected selectableSize?: number;
+  protected width?: number;
+  protected height?: number;
 
   constructor(id: string) {
     this.id = id;
+    this.version = 0;
   }
 
   getID(): string {
     return this.id;
+  }
+
+  setVersion(version: number) {
+    this.version = version;
+  }
+
+  getVersion(): number {
+    return this.version;
   }
 
   abstract getSelectableSize(): number;
@@ -14,4 +29,10 @@ export default abstract class LayoutNode {
   abstract getWidth(): number;
 
   abstract getHeight(): number;
+
+  protected clearCache() {
+    this.width = undefined;
+    this.height = undefined;
+    this.selectableSize = undefined;
+  }
 }

--- a/packages/core/src/layout/ParagraphBlockBox.ts
+++ b/packages/core/src/layout/ParagraphBlockBox.ts
@@ -16,8 +16,7 @@ export default class ParagraphBlockBox extends BlockBox {
     childrenCut.forEach((child, childOffset) => {
       newParagraphBlockBox.insertChild(child, childOffset);
     });
-    this.height = undefined;
-    this.selectableSize = undefined;
+    this.clearCache();
     return newParagraphBlockBox;
   }
 
@@ -30,8 +29,7 @@ export default class ParagraphBlockBox extends BlockBox {
       this.insertChild(child, childOffset);
       childOffset++;
     });
-    this.height = undefined;
-    this.selectableSize = undefined;
+    this.clearCache();
   }
 
   resolveViewportPositionToSelectableOffset(x: number, y: number): number {

--- a/packages/core/src/layout/TextAtomicBox.ts
+++ b/packages/core/src/layout/TextAtomicBox.ts
@@ -12,15 +12,7 @@ const stubTextStyle = {
 };
 
 export default class TextAtomicBox extends AtomicBox {
-  protected width?: number;
-  protected widthWithoutTrailingWhitespace?: number;
-  protected height?: number;
-  protected content: string;
-
-  constructor(renderNodeID: string) {
-    super(renderNodeID);
-    this.content = '';
-  }
+  protected content: string = '';
 
   getWidth(): number {
     if (this.width === undefined || this.height === undefined) {
@@ -63,8 +55,7 @@ export default class TextAtomicBox extends AtomicBox {
   onRenderUpdated(renderNode: TextAtomicRenderNode) {
     this.content = renderNode.getContent();
     this.breakable = renderNode.getBreakable();
-    this.width = undefined;
-    this.height = undefined;
+    this.clearCache();
   }
 
   resolveViewportPositionToSelectableOffset(x: number): number {

--- a/packages/core/src/layout/TextInlineBox.ts
+++ b/packages/core/src/layout/TextInlineBox.ts
@@ -15,9 +15,7 @@ export default class TextInlineBox extends InlineBox {
     childrenCut.forEach((child, childOffset) => {
       newTextInlineBox.insertChild(child, childOffset);
     });
-    this.width = undefined;
-    this.height = undefined;
-    this.selectableSize = undefined;
+    this.clearCache();
     return newTextInlineBox;
   }
 
@@ -30,7 +28,6 @@ export default class TextInlineBox extends InlineBox {
       this.insertChild(child, childOffset);
       childOffset++;
     });
-    this.height = undefined;
-    this.selectableSize = undefined;
+    this.clearCache();
   }
 }

--- a/packages/core/src/model/BlockElement.ts
+++ b/packages/core/src/model/BlockElement.ts
@@ -9,7 +9,6 @@ type ChildElement = InlineElement;
 export default abstract class BlockElement extends Element implements BranchNode {
   protected parent: ParentElement | null = null;
   protected children: ChildElement[] = [];
-  protected size?: number;
 
   setParent(parent: ParentElement | null) {
     this.parent = parent;
@@ -22,14 +21,14 @@ export default abstract class BlockElement extends Element implements BranchNode
     return this.parent;
   }
 
-  insertChild(child: ChildElement, offset: number | undefined = undefined) {
+  insertChild(child: ChildElement, offset: number | null = null) {
     child.setParent(this);
-    if (offset === undefined) {
+    if (offset === null) {
       this.children.push(child);
     } else {
       this.children.splice(offset, 0, child);
     }
-    this.size = undefined;
+    this.clearCache();
   }
 
   deleteChild(child: ChildElement) {
@@ -39,7 +38,7 @@ export default abstract class BlockElement extends Element implements BranchNode
     }
     child.setParent(null);
     this.children.splice(childOffset, 1);
-    this.size = undefined;
+    this.clearCache();
   }
 
   getChildren(): ChildElement[] {

--- a/packages/core/src/model/Doc.ts
+++ b/packages/core/src/model/Doc.ts
@@ -14,7 +14,6 @@ const DEFAULT_ATTRIBUTES = {
 
 export default class Doc extends Element implements RootNode {
   protected children: ChildElement[] = [];
-  protected size?: number;
   protected width: number = 0;
   protected height: number = 0;
   protected padding: number = 0;
@@ -24,14 +23,14 @@ export default class Doc extends Element implements RootNode {
     return 'Doc';
   }
 
-  insertChild(child: ChildElement, offset: number | undefined = undefined) {
+  insertChild(child: ChildElement, offset: number | null = null) {
     child.setParent(this);
-    if (offset === undefined) {
+    if (offset === null) {
       this.children.push(child);
     } else {
       this.children.splice(offset, 0, child);
     }
-    this.size = undefined;
+    this.clearCache();
   }
 
   deleteChild(child: ChildElement) {
@@ -41,7 +40,7 @@ export default class Doc extends Element implements RootNode {
     }
     child.setParent(null);
     this.children.splice(childOffset, 1);
-    this.size = undefined;
+    this.clearCache();
   }
 
   getChildren() {

--- a/packages/core/src/model/Element.ts
+++ b/packages/core/src/model/Element.ts
@@ -4,6 +4,7 @@ import Attributes from '../state/Attributes';
 export default abstract class Element implements Node {
   protected id?: string;
   protected version: number = 0;
+  protected size?: number;
 
   abstract getType(): string;
 
@@ -31,4 +32,8 @@ export default abstract class Element implements Node {
   abstract getAttributes(): Attributes;
 
   abstract onStateUpdated(attributes: Attributes): boolean;
+
+  protected clearCache() {
+    this.size = undefined;
+  }
 }

--- a/packages/core/src/model/InlineElement.ts
+++ b/packages/core/src/model/InlineElement.ts
@@ -7,7 +7,6 @@ type ParentElement = BlockElement;
 export default abstract class InlineElement extends Element implements LeafNode {
   protected parent: ParentElement | null = null;
   protected content: string = '';
-  protected size?: number;
 
   setParent(parent: ParentElement | null) {
     this.parent = parent;
@@ -22,7 +21,7 @@ export default abstract class InlineElement extends Element implements LeafNode 
 
   setContent(content: string) {
     this.content = content;
-    this.size = undefined;
+    this.clearCache();
   }
 
   getContent(): string {

--- a/packages/core/src/render/AtomicRenderNode.ts
+++ b/packages/core/src/render/AtomicRenderNode.ts
@@ -5,24 +5,16 @@ import InlineRenderNode from './InlineRenderNode';
 export type Parent = InlineRenderNode;
 
 export default abstract class AtomicRenderNode extends RenderNode implements LeafNode {
-  protected version: number;
-  protected parent: Parent;
+  protected parent: Parent | null = null;
 
-  constructor(id: string, parent: Parent) {
-    super(id);
-    this.version = 0;
+  setParent(parent: Parent | null) {
     this.parent = parent;
   }
 
-  setVersion(version: number) {
-    this.version = version;
-  }
-
-  getVersion(): number {
-    return this.version;
-  }
-
   getParent(): Parent {
+    if (!this.parent) {
+      throw new Error('No parent has been set.');
+    }
     return this.parent;
   }
 

--- a/packages/core/src/render/BlockRenderNode.ts
+++ b/packages/core/src/render/BlockRenderNode.ts
@@ -8,18 +8,8 @@ export type Parent = DocRenderNode;
 export type Child = InlineRenderNode;
 
 export default abstract class BlockRenderNode extends RenderNode implements BranchNode {
-  protected version: number;
-  protected parent: Parent;
-  protected selectableSize?: number;
-  protected modelSize?: number;
-  protected children: Child[];
-
-  constructor(id: string, parent: Parent) {
-    super(id);
-    this.version = 0;
-    this.parent = parent;
-    this.children = [];
-  }
+  protected parent: Parent | null = null;
+  protected children: Child[] = [];
 
   setVersion(version: number) {
     this.version = version;
@@ -29,7 +19,14 @@ export default abstract class BlockRenderNode extends RenderNode implements Bran
     return this.version;
   }
 
+  setParent(parent: Parent | null) {
+    this.parent = parent;
+  }
+
   getParent(): Parent {
+    if (!this.parent) {
+      throw new Error('No parent has been set.');
+    }
     return this.parent;
   }
 
@@ -37,8 +34,15 @@ export default abstract class BlockRenderNode extends RenderNode implements Bran
     return this.children;
   }
 
-  insertChild(child: Child, offset: number) {
-    this.children.splice(offset, 0, child);
+  insertChild(child: Child, offset: number | null = null) {
+    child.setParent(this);
+    if (offset === null) {
+      this.children.push(child);
+    } else {
+      this.children.splice(offset, 0, child);
+    }
+    this.selectableSize = undefined;
+    this.modelSize = undefined;
   }
 
   deleteChild(child: Child) {
@@ -46,7 +50,10 @@ export default abstract class BlockRenderNode extends RenderNode implements Bran
     if (childOffset < 0) {
       throw new Error('Cannot delete child, child not found.');
     }
+    child.setParent(null);
     this.children.splice(childOffset, 1);
+    this.selectableSize = undefined;
+    this.modelSize = undefined;
   }
 
   onModelUpdated(element: BlockElement) {

--- a/packages/core/src/render/DocRenderNode.ts
+++ b/packages/core/src/render/DocRenderNode.ts
@@ -8,9 +8,6 @@ export type Child = BlockRenderNode;
 type OnUpdatedSubscriber = () => void;
 
 export default class DocRenderNode extends RenderNode implements RootNode {
-  protected version: number;
-  protected selectableSize?: number;
-  protected modelSize?: number;
   protected width: number;
   protected height: number;
   protected padding: number;
@@ -19,7 +16,6 @@ export default class DocRenderNode extends RenderNode implements RootNode {
 
   constructor(id: string) {
     super(id);
-    this.version = 0;
     this.width = 0;
     this.height = 0;
     this.padding = 0;
@@ -59,12 +55,14 @@ export default class DocRenderNode extends RenderNode implements RootNode {
     return this.height - this.padding - this.padding;
   }
 
-  getChildren(): Child[] {
-    return this.children;
-  }
-
-  insertChild(child: Child, offset: number) {
-    this.children.splice(offset, 0, child);
+  insertChild(child: Child, offset: number | null = null) {
+    child.setParent(this);
+    if (offset === null) {
+      this.children.push(child);
+    } else {
+      this.children.splice(offset, 0, child);
+    }
+    this.clearCache();
   }
 
   deleteChild(child: Child) {
@@ -72,7 +70,13 @@ export default class DocRenderNode extends RenderNode implements RootNode {
     if (childOffset < 0) {
       throw new Error('Cannot delete child, child not found.');
     }
+    child.setParent(null);
     this.children.splice(childOffset, 1);
+    this.clearCache();
+  }
+
+  getChildren(): Child[] {
+    return this.children;
   }
 
   getSelectableSize() {
@@ -117,8 +121,7 @@ export default class DocRenderNode extends RenderNode implements RootNode {
     this.width = element.getWidth();
     this.height = element.getHeight();
     this.padding = element.getPadding();
-    this.selectableSize = undefined;
-    this.modelSize = undefined;
+    this.clearCache();
   }
 
   subscribeOnUpdated(onUpdatedSubscriber: OnUpdatedSubscriber) {

--- a/packages/core/src/render/RenderEngine.ts
+++ b/packages/core/src/render/RenderEngine.ts
@@ -48,7 +48,7 @@ class ModelToRenderTreeSyncer extends TreeSyncer<Element, RenderNode> {
   insertNode(parent: RenderNode, srcNode: Element, offset: number) {
     if (parent instanceof DocRenderNode && srcNode instanceof BlockElement) {
       const BlockRenderNodeClass = this.config.getRenderNodeClass(srcNode.getType());
-      const blockRenderNode = new BlockRenderNodeClass(srcNode.getID(), parent);
+      const blockRenderNode = new BlockRenderNodeClass(srcNode.getID());
       if (!(blockRenderNode instanceof BlockRenderNode)) {
         throw new Error('Error inserting render node, expecting block render node.');
       }
@@ -58,7 +58,7 @@ class ModelToRenderTreeSyncer extends TreeSyncer<Element, RenderNode> {
     }
     if (parent instanceof BlockRenderNode && srcNode instanceof InlineElement) {
       const InlineRenderNodeClass = this.config.getRenderNodeClass(srcNode.getType());
-      const inlineRenderNode = new InlineRenderNodeClass(srcNode.getID(), parent);
+      const inlineRenderNode = new InlineRenderNodeClass(srcNode.getID());
       if (!(inlineRenderNode instanceof InlineRenderNode)) {
         throw new Error('Error inserting render node, expecting inline render node.');
       }

--- a/packages/core/src/render/RenderNode.ts
+++ b/packages/core/src/render/RenderNode.ts
@@ -1,8 +1,14 @@
-export default abstract class RenderNode {
+import Node from '../tree/Node';
+
+export default abstract class RenderNode implements Node {
   protected id: string;
+  protected version: number;
+  protected selectableSize?: number;
+  protected modelSize?: number;
 
   constructor(id: string) {
     this.id = id;
+    this.version = 0;
   }
 
   abstract getType(): string;
@@ -11,9 +17,22 @@ export default abstract class RenderNode {
     return this.id;
   }
 
+  setVersion(version: number) {
+    this.version = version;
+  }
+
+  getVersion(): number {
+    return this.version;
+  }
+
   abstract getSelectableSize(): number;
 
   abstract getModelSize(): number;
 
   abstract convertSelectableOffsetToModelOffset(selectableOffset: number): number;
+
+  protected clearCache() {
+    this.selectableSize = undefined;
+    this.modelSize = undefined;
+  }
 }

--- a/packages/core/src/render/TextAtomicRenderNode.ts
+++ b/packages/core/src/render/TextAtomicRenderNode.ts
@@ -4,8 +4,8 @@ export default class TextAtomicRenderNode extends AtomicRenderNode {
   protected content: string;
   protected breakable: boolean;
 
-  constructor(id: string, parent: Parent, content: string, breakable: boolean) {
-    super(id, parent);
+  constructor(id: string, content: string, breakable: boolean) {
+    super(id);
     this.content = content;
     this.breakable = breakable;
   }

--- a/packages/core/src/render/TextInlineRenderNode.ts
+++ b/packages/core/src/render/TextInlineRenderNode.ts
@@ -1,6 +1,6 @@
 import generateID from '../helpers/generateID';
 import Text from '../model/Text';
-import breakTextToWords, { Word } from './helpers/breakTextToWords';
+import breakTextToWords from './helpers/breakTextToWords';
 import InlineRenderNode from './InlineRenderNode';
 import TextAtomicRenderNode from './TextAtomicRenderNode';
 
@@ -24,16 +24,18 @@ export default class TextInlineRenderNode extends InlineRenderNode {
         }
       }
       if (atomOffset < 0) {
-        const atomicRenderNode = new TextAtomicRenderNode(`${element.getID()}-${generateID()}`, this, word.text, word.breakable);
+        const atomicRenderNode = new TextAtomicRenderNode(`${element.getID()}-${generateID()}`, word.text, word.breakable);
         atomicRenderNode.setVersion(this.version + 1);
-        this.children.splice(offset, 0, atomicRenderNode);
+        this.insertChild(atomicRenderNode, offset);
       } else {
-        this.children.splice(offset, atomOffset - offset);
+        for (let n = offset; n < atomOffset; n++) {
+          this.deleteChild(this.children[offset]);
+        }
       }
       offset++;
     });
-    if (offset < this.children.length) {
-      this.children.splice(offset, this.children.length - offset);
+    for (let n = offset; n < this.children.length; n++) {
+      this.deleteChild(this.children[offset]);
     }
   }
 }

--- a/packages/core/src/tree/BranchNode.ts
+++ b/packages/core/src/tree/BranchNode.ts
@@ -1,13 +1,14 @@
 import Node from './Node';
-import RootNode from './RootNode';
-import LeafNode from './LeafNode';
-
-type ParentNode = RootNode | BranchNode;
-type ChildNode = BranchNode | LeafNode;
 
 export default interface BranchNode extends Node {
 
-  getParent(): ParentNode;
+  setParent(parent: Node | null): void;
 
-  getChildren(): ChildNode[];
+  getParent(): Node;
+
+  insertChild(child: Node, offset: number | undefined): void;
+
+  deleteChild(child: Node): void;
+
+  getChildren(): Node[];
 }

--- a/packages/core/src/tree/LeafNode.ts
+++ b/packages/core/src/tree/LeafNode.ts
@@ -1,10 +1,8 @@
 import Node from './Node';
-import RootNode from './RootNode';
-import BranchNode from './BranchNode';
-
-type ParentNode = RootNode | BranchNode;
 
 export default interface LeafNode extends Node {
 
-  getParent(): ParentNode;
+  setParent(parent: Node | null): void;
+
+  getParent(): Node;
 }

--- a/packages/core/src/tree/RootNode.ts
+++ b/packages/core/src/tree/RootNode.ts
@@ -1,10 +1,10 @@
 import Node from './Node';
-import BranchNode from './BranchNode';
-import LeafNode from './LeafNode';
-
-type ChildNode = BranchNode | LeafNode;
 
 export default interface RootNode extends Node {
 
-  getChildren(): ChildNode[];
+  insertChild(child: Node, offset: number | undefined): void;
+
+  deleteChild(child: Node): void;
+
+  getChildren(): Node[];
 }

--- a/packages/core/src/view/BlockViewNode.ts
+++ b/packages/core/src/view/BlockViewNode.ts
@@ -1,15 +1,25 @@
+import BranchNode from '../tree/BranchNode';
 import BlockBox from '../layout/BlockBox';
 import ViewNode from './ViewNode';
+import PageViewNode from './PageViewNode';
 import LineViewNode from './LineViewNode';
 
+export type Parent = PageViewNode;
 export type Child = LineViewNode;
 
-export default abstract class BlockViewNode extends ViewNode {
-  protected children: Child[];
+export default abstract class BlockViewNode extends ViewNode implements BranchNode {
+  protected parent: Parent | null = null;
+  protected children: Child[] = [];
 
-  constructor(id: string) {
-    super(id);
-    this.children = [];
+  setParent(parent: Parent | null) {
+    this.parent = parent;
+  }
+
+  getParent(): Parent {
+    if (!this.parent) {
+      throw new Error(`No parent has been set.`);
+    }
+    return this.parent;
   }
 
   abstract insertChild(child: LineViewNode, offset: number): void;

--- a/packages/core/src/view/DOMObserver.ts
+++ b/packages/core/src/view/DOMObserver.ts
@@ -95,6 +95,8 @@ export default class DOMObserver {
     if (!isInPage) {
       return;
     }
+    // Bypass browser selection
+    event.preventDefault();
     this.isMouseDown = true;
     const offset = this.resolveScreenPosition(event.clientX, event.clientY);
     if (offset < 0) {

--- a/packages/core/src/view/DocViewNode.ts
+++ b/packages/core/src/view/DocViewNode.ts
@@ -1,3 +1,4 @@
+import RootNode from '../tree/RootNode';
 import DocBox from '../layout/DocBox';
 import ViewNode from './ViewNode';
 import PageViewNode from './PageViewNode';
@@ -6,19 +7,19 @@ type Child = PageViewNode;
 
 type OnUpdatedSubscriber = () => void;
 
-export default class DocViewNode extends ViewNode {
-  protected children: Child[];
+export default class DocViewNode extends ViewNode implements RootNode {
+  protected children: Child[] = [];
   protected domContainer: HTMLDivElement;
-  protected onUpdatedSubscribers: OnUpdatedSubscriber[];
+  protected onUpdatedSubscribers: OnUpdatedSubscriber[] = [];
 
   constructor(id: string) {
     super(id);
-    this.children = [];
-    this.onUpdatedSubscribers = [];
     this.domContainer = document.createElement('div');
     this.domContainer.contentEditable = 'true';
     this.domContainer.spellcheck = false;
     this.domContainer.className = 'tw--doc';
+    this.domContainer.setAttribute('data-tw-id', id);
+    this.domContainer.setAttribute('data-tw-role', 'doc');
     this.domContainer.style.outline = 'none';
     this.domContainer.style.textAlign = 'left';
   }
@@ -27,16 +28,22 @@ export default class DocViewNode extends ViewNode {
     return this.domContainer;
   }
 
-  insertChild(child: Child, offset: number) {
-    this.children.splice(offset, 0, child);
+  insertChild(child: Child, offset: number | null = null) {
     const childDOMContainer = child.getDOMContainer();
-    if (offset > this.domContainer.childNodes.length) {
-      throw new Error(`Error inserting child to view, offset ${offset} is out of range.`);
-    }
-    if (offset === this.domContainer.childNodes.length) {
+    child.setParent(this);
+    if (offset === null) {
+      this.children.push(child);
       this.domContainer.appendChild(childDOMContainer);
     } else {
-      this.domContainer.insertBefore(childDOMContainer, this.domContainer.childNodes[offset]);
+      this.children.splice(offset, 0, child);
+      if (offset > this.domContainer.childNodes.length) {
+        throw new Error(`Error inserting child to view, offset ${offset} is out of range.`);
+      }
+      if (offset === this.domContainer.childNodes.length) {
+        this.domContainer.appendChild(childDOMContainer);
+      } else {
+        this.domContainer.insertBefore(childDOMContainer, this.domContainer.childNodes[offset]);
+      }
     }
   }
 
@@ -45,7 +52,10 @@ export default class DocViewNode extends ViewNode {
     if (childOffset < 0) {
       throw new Error('Cannot delete child, child not found.');
     }
+    const childDOMContainer = child.getDOMContainer();
+    this.domContainer.removeChild(childDOMContainer);
     child.onDeleted();
+    child.setParent(null);
     this.children.splice(childOffset, 1);
   }
 

--- a/packages/core/src/view/InlineViewNode.ts
+++ b/packages/core/src/view/InlineViewNode.ts
@@ -1,7 +1,23 @@
+import LeafNode from '../tree/LeafNode';
 import InlineBox from '../layout/InlineBox';
 import ViewNode from './ViewNode';
+import LineViewNode from './LineViewNode';
 
-export default abstract class InlineViewNode extends ViewNode {
+export type Parent = LineViewNode;
+
+export default abstract class InlineViewNode extends ViewNode implements LeafNode {
+  protected parent: Parent | null = null;
+
+  setParent(parent: Parent | null) {
+    this.parent = parent;
+  }
+
+  getParent(): Parent {
+    if (!this.parent) {
+      throw new Error(`No parent has been set.`);
+    }
+    return this.parent;
+  }
 
   abstract onLayoutUpdated(layoutNode: InlineBox): void;
 

--- a/packages/core/src/view/Presenter.ts
+++ b/packages/core/src/view/Presenter.ts
@@ -235,18 +235,24 @@ export default class Presenter {
   }
 
   resolveDOMNodePosition(node: Node, offset: number): number {
-    // FIXME: This method is work in progress. It should try its
-    // best to resolve position, even if it may not be 100% accurate.
+    // This works by finding the nearest inline view node and
+    // resolving the position through the view node. If the
+    // DOM node is within a view node already, the DOM node
+    // and the offset are passed to the view node to resolve
+    // to a position. Otherwise, the closest posterior view node
+    // is used to resolve the position, assuming the cursor is at
+    // the beginning of the view node.
     let currentElement: HTMLElement | null = node instanceof HTMLElement ? node : node.parentElement;
     while (currentElement) {
       const nodeID = currentElement.getAttribute('data-tw-id');
       if (nodeID) {
         const idMapValue = this.idMap.get(nodeID);
         if (!idMapValue) {
-          return -1;
+          throw new Error(`View node ${nodeID} is not registered, even though it is in the DOM.`);
         }
         const [layoutNode, viewNode] = idMapValue;
         if (!(layoutNode instanceof InlineBox && viewNode instanceof InlineViewNode)) {
+          // TODO: Determine inline position
           return -1;
         }
         let resolvedOffset = viewNode.resolveSelectionOffset(offset);

--- a/packages/core/src/view/TextInlineViewNode.ts
+++ b/packages/core/src/view/TextInlineViewNode.ts
@@ -11,7 +11,7 @@ export default class TextInlineViewNode extends InlineViewNode {
     this.domContainer.className = 'tw--text-inline';
     this.domContainer.setAttribute('data-tw-id', id);
     this.domContainer.setAttribute('data-tw-role', 'inline');
-    this.domContainer.style.color = 'transparent';
+    // this.domContainer.style.color = 'transparent';
     this.domContainer.style.textShadow = '0 0 0 black';
   }
 
@@ -20,9 +20,6 @@ export default class TextInlineViewNode extends InlineViewNode {
   }
 
   onDeleted() {
-    if (this.domContainer.parentElement) {
-      this.domContainer.parentElement.removeChild(this.domContainer);
-    }
   }
 
   onLayoutUpdated(layoutNode: TextInlineBox) {

--- a/packages/core/src/view/TextInlineViewNode.ts
+++ b/packages/core/src/view/TextInlineViewNode.ts
@@ -11,7 +11,7 @@ export default class TextInlineViewNode extends InlineViewNode {
     this.domContainer.className = 'tw--text-inline';
     this.domContainer.setAttribute('data-tw-id', id);
     this.domContainer.setAttribute('data-tw-role', 'inline');
-    // this.domContainer.style.color = 'transparent';
+    this.domContainer.style.color = 'transparent';
     this.domContainer.style.textShadow = '0 0 0 black';
   }
 


### PR DESCRIPTION
Changes to render / layout / view trees to adopt tree interface. Adopting tree interface for the view tree adds bidirectional reference (parent & children), this will be useful for some edge cases when resolving DOM cursor position.