### PR TITLE
Use contenteditable in iframe for input capture

### DIFF
--- a/examples/taleweaver-example-react/src/samples/littleRedRidingHood.ts
+++ b/examples/taleweaver-example-react/src/samples/littleRedRidingHood.ts
@@ -176,4 +176,4 @@ export default `
     </>
   </>
 </>
-`.split('\n').map(line => line.trim()).join('').replace(/([^<])<\/>/g, '$1\n</>').replace(/{{id}}/g, () => `${Math.random().toString(36).substring(2)}`);
+`.split('\n').map(line => line.trim()).join('').replace(/([^>])<\/>/g, '$1\n</>').replace(/{{id}}/g, () => `${Math.random().toString(36).substring(2)}`);

--- a/packages/core/src/input/docCommands/deleteBackward.ts
+++ b/packages/core/src/input/docCommands/deleteBackward.ts
@@ -1,0 +1,44 @@
+import Editor from '../../Editor';
+import Command from '../Command';
+import StateTransformation from '../../state/Transformation';
+import CursorTransformation from '../../cursor/Transformation';
+import * as cursorOperations from '../../cursor/operations';
+import * as stateOperations from '../../state/operations';
+
+export default function deleteBackward(): Command {
+  return (editor: Editor): [StateTransformation, CursorTransformation] => {
+    const stateTransformation = new StateTransformation();
+    const cursorTransformation = new CursorTransformation();
+    const cursor = editor.getCursor();
+    if (!cursor) {
+      return [stateTransformation, cursorTransformation];
+    }
+    const anchor = cursor.getAnchor();
+    const head = cursor.getHead();
+    if (anchor === head) {
+      if (head < 1) {
+        return [stateTransformation, cursorTransformation];
+      }
+      stateTransformation.addOperation(new stateOperations.Delete(
+        editor.convertSelectableOffsetToModelOffset(head - 1),
+        editor.convertSelectableOffsetToModelOffset(head),
+      ));
+      cursorTransformation.addOperation(new cursorOperations.MoveTo(head - 1));
+    } else {
+      if (anchor < head) {
+        stateTransformation.addOperation(new stateOperations.Delete(
+          editor.convertSelectableOffsetToModelOffset(anchor),
+          editor.convertSelectableOffsetToModelOffset(head),
+        ));
+        cursorTransformation.addOperation(new cursorOperations.MoveTo(anchor));
+      } else if (anchor > head) {
+        stateTransformation.addOperation(new stateOperations.Delete(
+          editor.convertSelectableOffsetToModelOffset(head),
+          editor.convertSelectableOffsetToModelOffset(anchor),
+        ));
+        cursorTransformation.addOperation(new cursorOperations.MoveTo(head));
+      }
+    }
+    return [stateTransformation, cursorTransformation];
+  };
+}

--- a/packages/core/src/input/docCommands/deleteForward.ts
+++ b/packages/core/src/input/docCommands/deleteForward.ts
@@ -1,0 +1,44 @@
+import Editor from '../../Editor';
+import Command from '../Command';
+import StateTransformation from '../../state/Transformation';
+import CursorTransformation from '../../cursor/Transformation';
+import * as cursorOperations from '../../cursor/operations';
+import * as stateOperations from '../../state/operations';
+
+export default function deleteForward(): Command {
+  return (editor: Editor): [StateTransformation, CursorTransformation] => {
+    const stateTransformation = new StateTransformation();
+    const cursorTransformation = new CursorTransformation();
+    const cursor = editor.getCursor();
+    if (!cursor) {
+      return [stateTransformation, cursorTransformation];
+    }
+    const anchor = cursor.getAnchor();
+    const head = cursor.getHead();
+    const docBox = editor.getLayoutEngine().getDocBox();
+    if (anchor === head) {
+      if (head >= docBox.getSelectableSize() - 1) {
+        return [stateTransformation, cursorTransformation];
+      }
+      stateTransformation.addOperation(new stateOperations.Delete(
+        editor.convertSelectableOffsetToModelOffset(head),
+        editor.convertSelectableOffsetToModelOffset(head + 1),
+      ));
+    } else {
+      if (anchor < head) {
+        stateTransformation.addOperation(new stateOperations.Delete(
+          editor.convertSelectableOffsetToModelOffset(anchor),
+          editor.convertSelectableOffsetToModelOffset(head),
+        ));
+        cursorTransformation.addOperation(new cursorOperations.MoveTo(anchor));
+      } else if (anchor > head) {
+        stateTransformation.addOperation(new stateOperations.Delete(
+          editor.convertSelectableOffsetToModelOffset(head),
+          editor.convertSelectableOffsetToModelOffset(anchor),
+        ));
+        cursorTransformation.addOperation(new cursorOperations.MoveTo(head));
+      }
+    }
+    return [stateTransformation, cursorTransformation];
+  };
+}

--- a/packages/core/src/input/docCommands/index.ts
+++ b/packages/core/src/input/docCommands/index.ts
@@ -1,0 +1,11 @@
+import insert from './insert';
+import deleteBackward from './deleteBackward';
+import deleteForward from './deleteForward';
+import split from './split';
+
+export {
+  insert,
+  deleteBackward,
+  deleteForward,
+  split,
+};

--- a/packages/core/src/input/docCommands/insert.ts
+++ b/packages/core/src/input/docCommands/insert.ts
@@ -1,0 +1,39 @@
+import Editor from '../../Editor';
+import Command from '../Command';
+import StateTransformation from '../../state/Transformation';
+import CursorTransformation from '../../cursor/Transformation';
+import * as cursorOperations from '../../cursor/operations';
+import * as stateOperations from '../../state/operations';
+import Token from '../../state/Token';
+
+export default function insert(tokens: Token[]): Command {
+  return (editor: Editor): [StateTransformation, CursorTransformation] => {
+    const stateTransformation = new StateTransformation();
+    const cursorTransformation = new CursorTransformation();
+    const cursor = editor.getCursor();
+    if (!cursor) {
+      return [stateTransformation, cursorTransformation];
+    }
+    const anchor = cursor.getAnchor();
+    const head = cursor.getHead();
+    let collapsedAt = anchor;
+    if (anchor < head) {
+      stateTransformation.addOperation(new stateOperations.Delete(
+        editor.convertSelectableOffsetToModelOffset(anchor),
+        editor.convertSelectableOffsetToModelOffset(head),
+      ));
+    } else if (anchor > head) {
+      stateTransformation.addOperation(new stateOperations.Delete(
+        editor.convertSelectableOffsetToModelOffset(head),
+        editor.convertSelectableOffsetToModelOffset(anchor),
+      ));
+      collapsedAt = head;
+    }
+    stateTransformation.addOperation(new stateOperations.Insert(
+      editor.convertSelectableOffsetToModelOffset(collapsedAt),
+      tokens,
+    ));
+    cursorTransformation.addOperation(new cursorOperations.MoveTo(collapsedAt + tokens.filter(t => typeof(t) === 'string').length));
+    return [stateTransformation, cursorTransformation];
+  };
+}

--- a/packages/core/src/input/docCommands/split.ts
+++ b/packages/core/src/input/docCommands/split.ts
@@ -1,0 +1,68 @@
+import Editor from '../../Editor';
+import Command from '../Command';
+import StateTransformation from '../../state/Transformation';
+import CursorTransformation from '../../cursor/Transformation';
+import * as cursorOperations from '../../cursor/operations';
+import * as stateOperations from '../../state/operations';
+import Token from '../../state/Token';
+import OpenTagToken from '../../state/OpenTagToken';
+import CloseTagToken from '../../state/CloseTagToken';
+import generateID from '../../helpers/generateID';
+
+export default function split(): Command {
+  return (editor: Editor): [StateTransformation, CursorTransformation] => {
+    const stateTransformation = new StateTransformation();
+    const cursorTransformation = new CursorTransformation();
+    const cursor = editor.getCursor();
+    if (!cursor) {
+      return [stateTransformation, cursorTransformation];
+    }
+    const anchor = cursor.getAnchor();
+    const head = cursor.getHead();
+    let collapsedAt = anchor;
+    if (anchor < head) {
+      stateTransformation.addOperation(new stateOperations.Delete(
+        editor.convertSelectableOffsetToModelOffset(anchor),
+        editor.convertSelectableOffsetToModelOffset(head),
+      ));
+    } else if (anchor > head) {
+      stateTransformation.addOperation(new stateOperations.Delete(
+        editor.convertSelectableOffsetToModelOffset(head),
+        editor.convertSelectableOffsetToModelOffset(anchor),
+      ));
+      collapsedAt = head;
+    }
+    // Find preceding inline and block open tags
+    const stateCollapsedAt = editor.convertSelectableOffsetToModelOffset(collapsedAt);
+    const tokens = editor.getState().getTokens();
+    let inlineOpenTagToken: OpenTagToken | null = null;
+    let blockOpenTagToken: OpenTagToken | null = null;
+    let token: Token;
+    for (let n = stateCollapsedAt; n > 0; n--) {
+      token = tokens[n];
+      if (!(token instanceof OpenTagToken)) {
+        continue;
+      }
+      if (inlineOpenTagToken === null) {
+        inlineOpenTagToken = token;
+      } else if (blockOpenTagToken === null) {
+        blockOpenTagToken = token;
+      }
+    }
+    if (inlineOpenTagToken === null || blockOpenTagToken === null) {
+      throw new Error('State is corrupted, cannot perform split.');
+    }
+    stateTransformation.addOperation(new stateOperations.Insert(
+      editor.convertSelectableOffsetToModelOffset(collapsedAt),
+      [
+        '\n',
+        new CloseTagToken(), // Close inline
+        new CloseTagToken(), // Close block
+        new OpenTagToken(blockOpenTagToken.getType(), generateID(), blockOpenTagToken.getAttributes()), // Open block
+        new OpenTagToken(inlineOpenTagToken.getType(), generateID(), inlineOpenTagToken.getAttributes()), // Open inline
+      ],
+    ));
+    cursorTransformation.addOperation(new cursorOperations.MoveTo(collapsedAt + 1));
+    return [stateTransformation, cursorTransformation];
+  };
+}

--- a/packages/core/src/model/Parser.ts
+++ b/packages/core/src/model/Parser.ts
@@ -243,7 +243,7 @@ class Parser {
       throw new Error('Expected doc.');
     }
     const attributes = token.getAttributes();
-    doc.setID(attributes.id);
+    doc.setID(token.getID());
     doc.onStateUpdated(attributes);
     this.parserState = ParserState.NewElement;
   }
@@ -256,7 +256,7 @@ class Parser {
     const ElementClass = this.config.getElementClass(token.getType());
     const element = new ElementClass();
     const attributes = token.getAttributes();
-    element.setID(attributes.id);
+    element.setID(token.getID());
     element.onStateUpdated(attributes);
     if (parentElement instanceof Doc) {
       if (!(element instanceof BlockElement)) {

--- a/packages/core/src/render/TextInlineRenderNode.ts
+++ b/packages/core/src/render/TextInlineRenderNode.ts
@@ -34,7 +34,7 @@ export default class TextInlineRenderNode extends InlineRenderNode {
       }
       offset++;
     });
-    for (let n = offset; n < this.children.length; n++) {
+    for (let n = offset, nn = this.children.length; n < nn; n++) {
       this.deleteChild(this.children[offset]);
     }
   }

--- a/packages/core/src/state/Attributes.ts
+++ b/packages/core/src/state/Attributes.ts
@@ -1,4 +1,3 @@
 export default interface Attributes {
-  id: string;
   [key: string]: any;
 }

--- a/packages/core/src/state/OpenTagToken.ts
+++ b/packages/core/src/state/OpenTagToken.ts
@@ -2,15 +2,21 @@ import Attributes from './Attributes';
 
 class OpenTagToken {
   protected type: string;
+  protected id: string;
   protected attributes: Attributes;
 
-  constructor(type: string, attributes: Attributes) {
+  constructor(type: string, id: string, attributes: Attributes) {
     this.type = type;
+    this.id = id;
     this.attributes = attributes;
   }
 
   getType(): string {
     return this.type;
+  }
+
+  getID(): string {
+    return this.id;
   }
 
   getAttributes(): Attributes {

--- a/packages/core/src/state/Tokenizer.ts
+++ b/packages/core/src/state/Tokenizer.ts
@@ -142,19 +142,20 @@ class Tokenizer {
   }
 
   protected endTag(char: string) {
+    let id: string;
     let attributes: {};
     try {
-      attributes = JSON.parse(this.attributesBuffer);
+      ({ id, attributes } = JSON.parse(this.attributesBuffer));
     } catch (error) {
       throw new Error(`Invalid attributes JSON: ${this.attributesBuffer}.`);
     }
-    if (!('id' in attributes)) {
+    if (!id) {
       throw new Error(`Missing id in attributes JSON: ${this.attributesBuffer}.`);
     }
     if (!this.tagBuffer) {
       throw new Error('Open tag type cannot be empty.');
     }
-    const openTagToken = new OpenTagToken(this.tagBuffer, attributes);
+    const openTagToken = new OpenTagToken(this.tagBuffer, id, attributes);
     this.tokens.push(openTagToken);
     this.attributesBuffer = '';
     this.tagBuffer = '';

--- a/packages/core/src/view/CursorView.ts
+++ b/packages/core/src/view/CursorView.ts
@@ -2,32 +2,6 @@ import Editor from '../Editor';
 import Cursor from '../cursor/Cursor';
 import DocBox from '../layout/DocBox';
 import PageViewNode from './PageViewNode';
-import KeySignature from '../input/KeySignature';
-import * as keys from '../input/keys';
-import * as modifierKeys from '../input/modifierKeys';
-import {
-  moveLeft,
-  moveRight,
-  moveHeadLeft,
-  moveHeadRight,
-  moveLeftByWord,
-  moveRightByWord,
-  moveHeadLeftByWord,
-  moveHeadRightByWord,
-  moveToLeftOfLine,
-  moveToRightOfLine,
-  moveHeadToLeftOfLine,
-  moveHeadToRightOfLine,
-  moveToLineAbove,
-  moveToLineBelow,
-  moveHeadToLineAbove,
-  moveHeadToLineBelow,
-  moveToRightOfDoc,
-  moveToLeftOfDoc,
-  moveHeadToRightOfDoc,
-  moveHeadToLeftOfDoc,
-  selectAll,
-} from '../input/cursorCommands';
 
 export default class CursorView {
   protected editor: Editor;
@@ -51,7 +25,6 @@ export default class CursorView {
     this.domCaret.style.marginLeft = '-1px';
     this.domCaret.style.background = 'hsla(213, 100%, 50%, 1)';
     this.domSelections = [];
-    this.bindKeys();
   }
 
   onUpdated(cursor: Cursor, docBox: DocBox, pageViewNodes: PageViewNode[]) {
@@ -159,51 +132,9 @@ export default class CursorView {
 
     // Scroll cursor head into view
     this.domCaret.scrollIntoView({ block: 'nearest' });
-    
-    // Set browser selection to be consistent with new cursor position
-    const docViewNode = this.editor.getPresenter().getDocViewNode();
-    const [anchorNode, anchorNodeOffset] = docViewNode.resolveSelectableOffsetToNodeOffset(anchor);
-    const [headNode, headNodeOffset] = docViewNode.resolveSelectableOffsetToNodeOffset(head);
-    const selectionRange = document.createRange();
-    if (anchor < head) {
-      selectionRange.setStart(anchorNode, anchorNodeOffset);
-      selectionRange.setEnd(headNode, headNodeOffset);
-    } else {
-      selectionRange.setStart(headNode, headNodeOffset);
-      selectionRange.setEnd(anchorNode, anchorNodeOffset);
-    }
-    const selection = window.getSelection();
-    selection.empty();
-    selection.addRange(selectionRange);
 
     // Reset blinking
     this.stopBlinking();
     this.startBlinking();
-  }
-
-  protected bindKeys() {
-    const config = this.editor.getConfig();
-    const dispatcher = this.editor.getDispatcher();
-    config.bindKey(new KeySignature(keys.ArrowLeftKey), () => dispatcher.dispatchCommand(moveLeft()));
-    config.bindKey(new KeySignature(keys.ArrowRightKey), () => dispatcher.dispatchCommand(moveRight()));
-    config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadLeft()));
-    config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadRight()));
-    config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.AltKey]), () => dispatcher.dispatchCommand(moveLeftByWord()));
-    config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.AltKey]), () => dispatcher.dispatchCommand(moveRightByWord()));
-    config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.AltKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadLeftByWord()));
-    config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.AltKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadRightByWord()));
-    config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToLeftOfLine()));
-    config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToRightOfLine()));
-    config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLeftOfLine()));
-    config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToRightOfLine()));
-    config.bindKey(new KeySignature(keys.ArrowUpKey), () => dispatcher.dispatchCommand(moveToLineAbove()));
-    config.bindKey(new KeySignature(keys.ArrowDownKey), () => dispatcher.dispatchCommand(moveToLineBelow()));
-    config.bindKey(new KeySignature(keys.ArrowUpKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLineAbove()));
-    config.bindKey(new KeySignature(keys.ArrowDownKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLineBelow()));
-    config.bindKey(new KeySignature(keys.ArrowUpKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToLeftOfDoc()));
-    config.bindKey(new KeySignature(keys.ArrowDownKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToRightOfDoc()));
-    config.bindKey(new KeySignature(keys.ArrowUpKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLeftOfDoc()));
-    config.bindKey(new KeySignature(keys.ArrowDownKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToRightOfDoc()));
-    config.bindKey(new KeySignature(keys.AKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(selectAll()));
   }
 }

--- a/packages/core/src/view/DocViewNode.ts
+++ b/packages/core/src/view/DocViewNode.ts
@@ -15,12 +15,9 @@ export default class DocViewNode extends ViewNode implements RootNode {
   constructor(id: string) {
     super(id);
     this.domContainer = document.createElement('div');
-    this.domContainer.contentEditable = 'true';
-    this.domContainer.spellcheck = false;
     this.domContainer.className = 'tw--doc';
     this.domContainer.setAttribute('data-tw-id', id);
     this.domContainer.setAttribute('data-tw-role', 'doc');
-    this.domContainer.style.outline = 'none';
     this.domContainer.style.textAlign = 'left';
   }
 

--- a/packages/core/src/view/bindKeys.ts
+++ b/packages/core/src/view/bindKeys.ts
@@ -1,0 +1,73 @@
+import Editor from '../Editor';
+import Config from '../Config';
+import Dispatcher from '../input/Dispatcher';
+import KeySignature from '../input/KeySignature';
+import * as keys from '../input/keys';
+import * as modifierKeys from '../input/modifierKeys';
+import {
+  moveLeft,
+  moveRight,
+  moveHeadLeft,
+  moveHeadRight,
+  moveLeftByWord,
+  moveRightByWord,
+  moveHeadLeftByWord,
+  moveHeadRightByWord,
+  moveToLeftOfLine,
+  moveToRightOfLine,
+  moveHeadToLeftOfLine,
+  moveHeadToRightOfLine,
+  moveToLineAbove,
+  moveToLineBelow,
+  moveHeadToLineAbove,
+  moveHeadToLineBelow,
+  moveToRightOfDoc,
+  moveToLeftOfDoc,
+  moveHeadToRightOfDoc,
+  moveHeadToLeftOfDoc,
+  selectAll,
+} from '../input/cursorCommands';
+import {
+  deleteBackward,
+  deleteForward,
+  split,
+} from '../input/docCommands';
+
+function bindCursorNavivagateKeys(config: Config, dispatcher: Dispatcher) {
+  config.bindKey(new KeySignature(keys.ArrowLeftKey), () => dispatcher.dispatchCommand(moveLeft()));
+  config.bindKey(new KeySignature(keys.ArrowRightKey), () => dispatcher.dispatchCommand(moveRight()));
+  config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadLeft()));
+  config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadRight()));
+  config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.AltKey]), () => dispatcher.dispatchCommand(moveLeftByWord()));
+  config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.AltKey]), () => dispatcher.dispatchCommand(moveRightByWord()));
+  config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.AltKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadLeftByWord()));
+  config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.AltKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadRightByWord()));
+  config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToLeftOfLine()));
+  config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToRightOfLine()));
+  config.bindKey(new KeySignature(keys.ArrowLeftKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLeftOfLine()));
+  config.bindKey(new KeySignature(keys.ArrowRightKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToRightOfLine()));
+  config.bindKey(new KeySignature(keys.ArrowUpKey), () => dispatcher.dispatchCommand(moveToLineAbove()));
+  config.bindKey(new KeySignature(keys.ArrowDownKey), () => dispatcher.dispatchCommand(moveToLineBelow()));
+  config.bindKey(new KeySignature(keys.ArrowUpKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLineAbove()));
+  config.bindKey(new KeySignature(keys.ArrowDownKey, [modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLineBelow()));
+  config.bindKey(new KeySignature(keys.ArrowUpKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToLeftOfDoc()));
+  config.bindKey(new KeySignature(keys.ArrowDownKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(moveToRightOfDoc()));
+  config.bindKey(new KeySignature(keys.ArrowUpKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToLeftOfDoc()));
+  config.bindKey(new KeySignature(keys.ArrowDownKey, [modifierKeys.MetaKey, modifierKeys.ShiftKey]), () => dispatcher.dispatchCommand(moveHeadToRightOfDoc()));
+  config.bindKey(new KeySignature(keys.AKey, [modifierKeys.MetaKey]), () => dispatcher.dispatchCommand(selectAll()));
+}
+
+function bindDocEditKeys(config: Config, dispatcher: Dispatcher) {
+  config.bindKey(new KeySignature(keys.BackspaceKey), () => dispatcher.dispatchCommand(deleteBackward()));
+  config.bindKey(new KeySignature(keys.DeleteKey), () => dispatcher.dispatchCommand(deleteForward()));
+  config.bindKey(new KeySignature(keys.EnterKey), () => dispatcher.dispatchCommand(split()));
+}
+
+function bindKeys(editor: Editor) {
+  const config = editor.getConfig();
+  const dispatcher = editor.getDispatcher();
+  bindCursorNavivagateKeys(config, dispatcher);
+  bindDocEditKeys(config, dispatcher);
+}
+
+export default bindKeys;


### PR DESCRIPTION
The previous strategy of making the entire doc contenteditable and using MutationObserver to observe for changes and then undoing them seems to be too flaky. Trying a different approach, where contenteditable is used in an iframe to observe inputs.

This has the advantage of not needing to undo changes in the DOM and not using DOM cursor tracking.

The disadvantage is mobile cannot be supported with this approach. I think we can implement "light" layout and view layers for mobile where we delegate view-level line breaking to the browser (like other existing WYSIWYG editors, but still keep track of how lines are laid out) and not have pagination support for mobile (only one "page"). The undoing of changes to contenteditable also makes mobile input behave strangely, because the undo resets the browser input state.