### PR TITLE
Process multiple transformations together

### DIFF
--- a/packages/core/src/token/TokenManager.ts
+++ b/packages/core/src/token/TokenManager.ts
@@ -19,12 +19,12 @@ class TokenManager {
     return this.tokenState;
   }
 
-  applyTransformation(transformation: Transformation) {
-    return this.tokenState.applyTransformation(transformation);
+  applyTransformations(transformations: Transformation[]) {
+    return this.tokenState.applyTransformations(transformations);
   }
 
-  unapplyTransformation(appliedTransformation: AppliedTransformation) {
-    this.tokenState.unapplyTransformation(appliedTransformation);
+  unapplyTransformations(appliedTransformations: AppliedTransformation[]) {
+    this.tokenState.unapplyTransformations(appliedTransformations);
   }
 }
 


### PR DESCRIPTION
https://github.com/yuzhenmi/taleweaver/issues/28

Instead of processing transformations one by one, each time dispatching the `TokenStateUpdatedEvent`, which triggers trees to be updated, modify APIs to allow multiple transformations to be processed before dispatching the event. This speeds up undo and redo, where potentially multiple transformations are applied or reverted.