### PR TITLE
Measure text with canvas

### DIFF
--- a/packages/core/src/layout/InlineBox.ts
+++ b/packages/core/src/layout/InlineBox.ts
@@ -60,11 +60,11 @@ export default abstract class InlineBox extends Box {
   }
 
   getPaddingTop() {
-    return 0;
+    return 3;
   }
 
   getPaddingBottom() {
-    return 9;
+    return 6;
   }
 
   getPaddingLeft() {

--- a/packages/core/src/layout/TextAtomicBox.ts
+++ b/packages/core/src/layout/TextAtomicBox.ts
@@ -8,10 +8,9 @@ export default class TextAtomicBox extends AtomicBox {
   protected height?: number;
   protected content: string = '';
   protected textStyle: TextStyle = {
-    fontFamily: 'sans-serif',
+    fontFamily: 'Source Sans Pro',
     fontSize: 18,
     fontWeight: 400,
-    letterSpacing: 0,
   };
 
   getWidth() {

--- a/packages/core/src/layout/utils/TextStyle.ts
+++ b/packages/core/src/layout/utils/TextStyle.ts
@@ -2,7 +2,6 @@ type TextStyle = {
   fontFamily: string;
   fontSize: number;
   fontWeight: number;
-  letterSpacing: number;
 }
 
 export default TextStyle;

--- a/packages/core/src/layout/utils/measureText.ts
+++ b/packages/core/src/layout/utils/measureText.ts
@@ -5,67 +5,22 @@ type Measurement = {
   height: number;
 };
 
-function getTextStyleKey(textStyle: TextStyle): string {
-  return JSON.stringify(textStyle);
-}
-
 export class TextMeasurer {
-  protected $iframe: HTMLIFrameElement;
-  protected $textContainers: Map<string, HTMLSpanElement>;
+  protected $canvas: HTMLCanvasElement;
 
   constructor() {
-    this.$iframe = document.createElement('iframe');
-    this.$iframe.scrolling = 'no';
-    this.$iframe.src = 'about:blank';
-    this.$iframe.style.width = '0';
-    this.$iframe.style.height = '0';
-    this.$iframe.style.border = 'none';
-    this.$iframe.style.position = 'fixed';
-    this.$iframe.style.zIndex = '-1';
-    this.$iframe.style.opacity = '0';
-    this.$iframe.style.overflow = 'hidden';
-    this.$iframe.style.left = '-1000000px';
-    this.$iframe.style.top = '-1000000px';
-    document.body.appendChild(this.$iframe);
-    this.$textContainers = new Map();
-    // On Firefox, iframe seems to reset after
-    // first loop so we also reset cached text
-    // containers in case they get initialized
-    // before the reset.
-    setTimeout(() => {
-      this.$textContainers.clear();
-    });
-  }
-
-  getTextContainerElement(textStyle: TextStyle): HTMLSpanElement {
-    const textStyleKey = getTextStyleKey(textStyle);
-    if (!this.$textContainers.has(textStyleKey)) {
-      const $textContainer = document.createElement('span');
-      $textContainer.style.display = 'inline-block';
-      $textContainer.style.whiteSpace = 'pre';
-      $textContainer.style.fontFamily = textStyle.fontFamily;
-      $textContainer.style.fontSize = `${textStyle.fontSize}px`;
-      $textContainer.style.fontWeight = `${textStyle.fontWeight}`;
-      $textContainer.style.lineHeight = '1.5em';
-      $textContainer.style.letterSpacing = `${textStyle.letterSpacing}`;
-      this.$iframe.contentDocument!.body.appendChild($textContainer);
-      this.$textContainers.set(textStyleKey, $textContainer);
-    }
-    const $textContainer = this.$textContainers.get(textStyleKey);
-    return $textContainer!;
+    this.$canvas = document.createElement('canvas');
   }
 
   measure(text: string, textStyle: TextStyle) {
     // Substitute trailing new line with space
     const adjustedText = text.replace(/\n$/, ' ');
-    const $textContainer = this.getTextContainerElement(textStyle);
-    if ($textContainer.innerText !== adjustedText) {
-      $textContainer.innerText = adjustedText;
-    }
-    const boundingClientRect = $textContainer.getBoundingClientRect();
+    const ctx = this.$canvas.getContext('2d')!;
+    ctx.font = `${textStyle.fontWeight} ${textStyle.fontSize}px "${textStyle.fontFamily}"`;
+    const measurement = ctx.measureText(adjustedText);
     return {
-      width: boundingClientRect.width,
-      height: boundingClientRect.height,
+      width: measurement.width,
+      height: textStyle.fontSize,
     };
   }
 }

--- a/packages/core/src/view/CursorView.ts
+++ b/packages/core/src/view/CursorView.ts
@@ -100,7 +100,7 @@ export default class CursorView {
         const domSelection = document.createElement('div');
         domSelection.className = 'tw--cursor-selection'
         domSelection.style.position = 'absolute';
-        domSelection.style.top = `${viewportBoundingRect.top}px`;
+        domSelection.style.top = `${viewportBoundingRect.top - viewportBoundingRect.paddingTop}px`;
         domSelection.style.left = `${viewportBoundingRect.left}px`;
         domSelection.style.width = `${viewportBoundingRect.paddingLeft + viewportBoundingRect.width + viewportBoundingRect.paddingRight}px`;
         domSelection.style.height = `${viewportBoundingRect.paddingTop + viewportBoundingRect.height + viewportBoundingRect.paddingBottom}px`;
@@ -156,12 +156,7 @@ export default class CursorView {
       }
     } else {
       this.domCaret.style.display = 'none';
-    }
-    // Scroll cursor head into view, if focused
-    if (isFocused) {
-      setTimeout(() => {
-        this.domCaret.scrollIntoView({ block: 'nearest' });
-      });
+      this.stopBlinking();
     }
   }
 }

--- a/packages/core/src/view/LineViewNode.ts
+++ b/packages/core/src/view/LineViewNode.ts
@@ -19,7 +19,8 @@ export default class LineViewNode extends ViewNode implements BranchNode {
     this.domContainer.className = 'tw--line';
     this.domContainer.setAttribute('data-tw-id', id);
     this.domContainer.setAttribute('data-tw-role', 'line');
-    this.domContainer.style.whiteSpace = 'pre-wrap';
+    this.domContainer.style.whiteSpace = 'pre';
+    this.domContainer.style.lineHeight = '0';
   }
 
   getDOMContainer() {

--- a/packages/core/src/view/TextInlineViewNode.ts
+++ b/packages/core/src/view/TextInlineViewNode.ts
@@ -13,9 +13,10 @@ export default class TextInlineViewNode extends InlineViewNode {
     this.domContainer.setAttribute('data-tw-id', id);
     this.domContainer.setAttribute('data-tw-role', 'inline');
     this.domContainer.style.display = 'inline-block';
+    this.domContainer.style.whiteSpace = 'pre';
     this.domContainer.style.color = 'black';
     this.domContainer.style.fontSize = '18px';
-    this.domContainer.style.lineHeight = '1.5em';
+    this.domContainer.style.lineHeight = '1em';
     this.domContainer.style.paddingTop = '0px';
     this.domContainer.style.paddingBottom = '0px';
   }


### PR DESCRIPTION
Using iframe to measure text has the disadvantage of requiring fonts to be loaded into the iframe, and is apparently less performance than canvas. So, let's switch to canvas for measuring texts and see how it goes.