### PR TITLE
Fix reflow when block at page bottom is changed

### DIFF
--- a/packages/core/lib/layout/LayoutEngine.ts
+++ b/packages/core/lib/layout/LayoutEngine.ts
@@ -37,6 +37,7 @@ export default class LayoutEngine {
         const layoutTreeBuilder = new LayoutTreeBuilder(this.editor, updatedRenderNode);
         const updatedNode = layoutTreeBuilder.run();
         node.onUpdated(updatedNode);
+        this.deduplicateNode(node);
         this.clearAncestorsCache(node);
         const layoutReflower = new LayoutReflower(this.editor, node);
         const reflowedNode = layoutReflower.run();
@@ -51,6 +52,19 @@ export default class LayoutEngine {
                 break;
             }
             currentNode = currentNode.getParent();
+        }
+    }
+
+    protected deduplicateNode(node: AnyLayoutNode) {
+        if (node.isRoot()) {
+            return;
+        }
+        let nextNode = node.getNextSiblingAllowCrossParent();
+        let nodeToDelete: AnyLayoutNode;
+        while (nextNode && nextNode.getID() === node.getID()) {
+            nodeToDelete = nextNode;
+            nextNode = nextNode.getNextSiblingAllowCrossParent();
+            nodeToDelete.getParent()!.removeChild(nodeToDelete);
         }
     }
 }

--- a/packages/core/lib/layout/LayoutReflower.ts
+++ b/packages/core/lib/layout/LayoutReflower.ts
@@ -187,6 +187,7 @@ export default class LayoutReflower {
                 const nextLineNode = currentLineNode.getNextSibling()!;
                 currentLineNode.join(nextLineNode);
                 nextLineNode.getParent()!.removeChild(nextLineNode);
+                this.lineNodeReflowStatuses.set(nextLineNode.getID(), true);
             }
             const newLineNode = this.breakLineNode(currentLineNode, maxWidth);
             if (!newLineNode) {
@@ -218,6 +219,7 @@ export default class LayoutReflower {
                 const nextPageNode = currentPageNode.getNextSibling()!;
                 currentPageNode.join(nextPageNode);
                 nextPageNode.getParent()!.removeChild(nextPageNode);
+                this.pageNodeReflowStatuses.set(nextPageNode.getID(), true);
             }
             const newPageNode = this.breakPageNode(currentPageNode, maxHeight);
             if (!newPageNode) {


### PR DESCRIPTION
When a block is split between 2 pages, 2 copies of the block are present in the layout tree, one on each page. When the block gets updated, the full block content gets set on the first copy and goes through reflow, but the second copy does not get cleaned up, so the second copy gets duplicated in the tree.

This PR adds code to clean up the duplicated block.