### PR TITLE
Text direction

### DIFF
--- a/examples/taleweaver-example-react/src/Editor/ToolBar.tsx
+++ b/examples/taleweaver-example-react/src/Editor/ToolBar.tsx
@@ -1,5 +1,6 @@
 import { Taleweaver } from '@taleweaver/core';
 import { ITextStyle } from '@taleweaver/core/dist/tw/component/components/text';
+import { IParagraphStyle } from '@taleweaver/core/dist/tw/component/components/paragraph';
 import React, { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
@@ -173,6 +174,14 @@ export default function ToolBar({ taleweaver }: Props) {
         },
         [],
     );
+    function setAlignment(alignment: IParagraphStyle["textAlign"]) {
+        if (!taleweaver) {
+            return;
+        }
+        taleweaver.getServiceRegistry()
+            .getService('command')
+            .executeCommand('tw.state.alignment', alignment)
+    }
     useEffect(() => {
         if (!taleweaver) {
             return;
@@ -246,6 +255,17 @@ export default function ToolBar({ taleweaver }: Props) {
                     <Item active={false} disabled={color === null} onClick={() => null}>
                         <i className="mdi mdi-format-color-text" style={{ position: 'relative', top: '-2px' }} />
                         <ItemColorLine color={color || 'transparent'} />
+                    </Item>
+                </Group>
+                <Group>
+                    <Item active={false} disabled={false} onClick={() => setAlignment('left')}>
+                        <i className="mdi mdi-format-align-left" />
+                    </Item>
+                    <Item active={false} disabled={false} onClick={() => setAlignment('center')}>
+                        <i className="mdi mdi-format-align-center" />
+                    </Item>
+                    <Item active={false} disabled={false} onClick={() => setAlignment('right')}>
+                        <i className="mdi mdi-format-align-right" />
                     </Item>
                 </Group>
             </Container>

--- a/packages/core/src/tw/component/components/paragraph.ts
+++ b/packages/core/src/tw/component/components/paragraph.ts
@@ -13,7 +13,10 @@ import { BlockViewNode } from '../../view/block-node';
 import { InlineViewNode } from '../../view/inline-node';
 import { Component, IComponent } from '../component';
 
-export interface IParagraphAttributes extends IAttributes {}
+export interface IParagraphAttributes extends IAttributes {
+    textAlign?: 'left' | 'right' | 'center';
+    direction?: 'rtl' | 'ltr';
+}
 
 export class ParagraphModelNode extends BlockModelNode<IParagraphAttributes> {
     getPartId() {
@@ -45,13 +48,13 @@ export class ParagraphModelNode extends BlockModelNode<IParagraphAttributes> {
 }
 
 export interface IParagraphStyle extends IStyle {
-    textAlign: 'left' | 'right' | 'center'
-    direction: 'rtl' | 'ltr'
+    textAlign: 'left' | 'right' | 'center';
+    direction: 'rtl' | 'ltr';
 }
 
 export const DEFAULT_PARAGRAPH_STYLE: IParagraphStyle = {
     textAlign: 'left',
-    direction: 'ltr'
+    direction: 'ltr',
 };
 export class ParagraphRenderNode extends BlockRenderNode<IParagraphStyle> {
     protected lineBreakNode: ParagraphLineBreakRenderNode;

--- a/packages/core/src/tw/component/components/paragraph.ts
+++ b/packages/core/src/tw/component/components/paragraph.ts
@@ -163,6 +163,11 @@ export class ParagraphLayoutNode extends BlockLayoutNode {
     clone() {
         return new ParagraphLayoutNode(this.componentId, this.id, this.style);
     }
+
+    onDidUpdate(updatedNode: this) {
+        super.onDidUpdate(updatedNode);
+        this.style = updatedNode.style;
+    }
 }
 
 export class ParagraphLineBreakLayoutNode extends InlineLayoutNode {

--- a/packages/core/src/tw/component/components/text.ts
+++ b/packages/core/src/tw/component/components/text.ts
@@ -150,6 +150,11 @@ export class TextLayoutNode extends InlineLayoutNode {
     clone() {
         return new TextLayoutNode(this.componentId, this.id, this.style);
     }
+
+    onDidUpdate(updatedNode: this) {
+        super.onDidUpdate(updatedNode);
+        this.style = updatedNode.style;
+    }
 }
 
 export class WordLayoutNode extends AtomicLayoutNode {

--- a/packages/core/src/tw/layout/flower.test.ts
+++ b/packages/core/src/tw/layout/flower.test.ts
@@ -1,7 +1,7 @@
 import { DocLayoutNode } from '../component/components/doc';
 import { LineLayoutNode } from '../component/components/line';
 import { PageLayoutNode } from '../component/components/page';
-import { ParagraphLayoutNode } from '../component/components/paragraph';
+import { ParagraphLayoutNode, DEFAULT_PARAGRAPH_STYLE } from '../component/components/paragraph';
 import { DEFAULT_TEXT_STYLE, TextLayoutNode, WordLayoutNode } from '../component/components/text';
 import { TextMeasurerStub } from '../component/components/text-measurer.stub';
 import { LayoutFlower } from './flower';
@@ -23,7 +23,7 @@ describe('LayoutFlower', () => {
                 docLayoutNode = new DocLayoutNode('doc', 'doc');
                 const pageLayoutNode = new PageLayoutNode('page', 88, 1056, 40, 40, 40, 40);
                 docLayoutNode.appendChild(pageLayoutNode);
-                const paragraphLayoutNode = new ParagraphLayoutNode('paragraph', '1');
+                const paragraphLayoutNode = new ParagraphLayoutNode('paragraph', '1', DEFAULT_PARAGRAPH_STYLE);
                 pageLayoutNode.appendChild(paragraphLayoutNode);
                 const lineLayoutNode = new LineLayoutNode('line');
                 paragraphLayoutNode.appendChild(lineLayoutNode);
@@ -90,7 +90,7 @@ describe('LayoutFlower', () => {
                 docLayoutNode = new DocLayoutNode('doc', 'doc');
                 const pageLayoutNode = new PageLayoutNode('page', 88, 108, 40, 40, 40, 40);
                 docLayoutNode.appendChild(pageLayoutNode);
-                const paragraphLayoutNode = new ParagraphLayoutNode('paragraph', '1');
+                const paragraphLayoutNode = new ParagraphLayoutNode('paragraph', '1', DEFAULT_PARAGRAPH_STYLE);
                 pageLayoutNode.appendChild(paragraphLayoutNode);
                 const lineLayoutNode = new LineLayoutNode('line');
                 paragraphLayoutNode.appendChild(lineLayoutNode);

--- a/packages/core/src/tw/layout/tree-builder.test.ts
+++ b/packages/core/src/tw/layout/tree-builder.test.ts
@@ -4,6 +4,7 @@ import {
     ParagraphLayoutNode,
     ParagraphLineBreakLayoutNode,
     ParagraphRenderNode,
+    DEFAULT_PARAGRAPH_STYLE,
 } from '../component/components/paragraph';
 import {
     DEFAULT_TEXT_STYLE,
@@ -34,7 +35,7 @@ describe('LayoutTreeBuilder', () => {
         configService = new ConfigService(config, {});
         componentService = new ComponentService(configService);
         docRenderNode = new DocRenderNode('doc', 'doc', {});
-        const paragraphRenderNode = new ParagraphRenderNode('paragraph', '1', {});
+        const paragraphRenderNode = new ParagraphRenderNode('paragraph', '1', DEFAULT_PARAGRAPH_STYLE);
         docRenderNode.appendChild(paragraphRenderNode);
         const textRenderNode1 = new TextRenderNode('text', '2', DEFAULT_TEXT_STYLE);
         const wordRenderNode1 = new WordRenderNode('text', '4', DEFAULT_TEXT_STYLE, {

--- a/packages/core/src/tw/model/node.ts
+++ b/packages/core/src/tw/model/node.ts
@@ -50,4 +50,9 @@ export abstract class ModelNode<TAttributes extends IAttributes, TParent extends
     getAttributes() {
         return this.attributes;
     }
+
+    onDidUpdate(updatedNode: this) {
+        super.onDidUpdate(updatedNode);
+        this.attributes = updatedNode.getAttributes();
+    }
 }

--- a/packages/core/src/tw/model/state.ts
+++ b/packages/core/src/tw/model/state.ts
@@ -40,7 +40,12 @@ export class ModelState implements IModelState {
 
     protected handleDidUpdateStateEvent = (event: IDidUpdateStateEvent) => {
         const wrappedDepth = this.findWrappedDepth(this.stateService.getTokens(), event.afterFrom, event.afterTo);
-        const node = this.findNodeContainingRange(event.beforeFrom, event.beforeTo, wrappedDepth);
+        let node
+        if (identifyTokenType(this.stateService.getTokens()[event.beforeFrom]) === 'OpenToken') {
+            node = this.docNode.resolvePosition(event.beforeFrom).getNode()
+        } else {
+            node = this.findNodeContainingRange(event.beforeFrom, event.beforeTo, wrappedDepth);
+        }
         const updatedTokens = this.findNodeTokenRange(
             this.stateService.getTokens(),
             node.getId(),

--- a/packages/core/src/tw/render/node.ts
+++ b/packages/core/src/tw/render/node.ts
@@ -49,4 +49,9 @@ export abstract class RenderNode<TStyle extends IStyle, TParent extends IRenderN
     getStyle() {
         return this.style;
     }
+
+    onDidUpdate(updatedNode: this) {
+        super.onDidUpdate(updatedNode);
+        this.style = updatedNode.style;
+    }
 }

--- a/packages/core/src/tw/render/service.test.ts
+++ b/packages/core/src/tw/render/service.test.ts
@@ -1,5 +1,5 @@
 import { DocComponent, DocModelNode } from '../component/components/doc';
-import { ParagraphComponent, ParagraphModelNode } from '../component/components/paragraph';
+import { ParagraphComponent, ParagraphModelNode, DEFAULT_PARAGRAPH_STYLE } from '../component/components/paragraph';
 import { TextComponent, TextModelNode } from '../component/components/text';
 import { TextMeasurerStub } from '../component/components/text-measurer.stub';
 import { ComponentService } from '../component/service';
@@ -67,7 +67,7 @@ describe('RenderService', () => {
             const styles1 = service.getStylesBetween(1, 2);
             expect(styles1).toEqual({
                 doc: { doc: [{}] },
-                paragraph: { paragraph: [{}] },
+                paragraph: { paragraph: [DEFAULT_PARAGRAPH_STYLE] },
                 text: {
                     text: [
                         {
@@ -98,7 +98,7 @@ describe('RenderService', () => {
             const styles2 = service.getStylesBetween(7, 8);
             expect(styles2).toEqual({
                 doc: { doc: [{}] },
-                paragraph: { paragraph: [{}] },
+                paragraph: { paragraph: [DEFAULT_PARAGRAPH_STYLE] },
                 text: {
                     text: [
                         {

--- a/packages/core/src/tw/state/transformation.ts
+++ b/packages/core/src/tw/state/transformation.ts
@@ -40,6 +40,36 @@ export interface IAppliedTransformation {
     getTransformedRange(): ITransformedRange | undefined;
 }
 
+export class AttributeOperation implements IOperation {
+    constructor(protected at: number, protected attributes: {}) {}
+
+    getOffsetAdjustment(): IOffsetAdjustment {
+        return {
+            at: this.at,
+            delta: 0,
+        };
+    }
+
+    adjustOffset(adjustments: IOffsetAdjustment[]) {
+        let at = this.at;
+        adjustments.forEach(adjustment => {
+            if (at >= adjustment.at) {
+                at += adjustment.delta;
+            }
+        });
+        return new AttributeOperation(at, this.attributes);
+    }
+
+    getAt() {
+        return this.at;
+    }
+
+    getAttributes() {
+        return this.attributes;
+    }
+
+}
+
 export class InsertOperation implements IOperation {
     constructor(protected at: number, protected tokens: IToken[]) {}
 
@@ -99,6 +129,18 @@ export class DeleteOperation implements IOperation {
 
     getTo() {
         return this.to;
+    }
+}
+
+export class AppliedAttributeOperation implements IAppliedOperation {
+    constructor(protected at: number, protected attributes: {}) {}
+
+    getAt() {
+        return this.at;
+    }
+
+    getAttributes() {
+        return this.attributes;
     }
 }
 
@@ -198,6 +240,12 @@ export class AppliedTransformation implements IAppliedTransformation {
             const deletedTokens = operation.getTokens();
             beforeFrom = at;
             beforeTo = at + deletedTokens.length;
+            afterFrom = at;
+            afterTo = at;
+        } else if (operation instanceof AppliedAttributeOperation) {
+            const at = operation.getAt();
+            beforeFrom = at;
+            beforeTo = at;
             afterFrom = at;
             afterTo = at;
         } else {

--- a/packages/core/src/tw/state/utility.ts
+++ b/packages/core/src/tw/state/utility.ts
@@ -1,4 +1,4 @@
-import { CLOSE_TOKEN, IToken } from './token';
+import { CLOSE_TOKEN, IToken, IOpenToken } from './token';
 
 export function identifyTokenType(token: IToken) {
     if (token === CLOSE_TOKEN) {
@@ -11,4 +11,11 @@ export function identifyTokenType(token: IToken) {
         return 'OpenToken';
     }
     throw new Error(`Failed to identify token type: ${token}.`);
+}
+
+export function identifyTokenModelType(token: IOpenToken) {
+    if (token.componentId === "paragraph") {
+        return 'Block';
+    }
+    return "Inline";
 }

--- a/packages/core/src/tw/taleweaver.ts
+++ b/packages/core/src/tw/taleweaver.ts
@@ -112,6 +112,7 @@ export class Taleweaver {
                 'tw.state.splitLine': stateCommandHandlers.splitLine,
                 'tw.view.focus': viewCommandHandlers.focus,
                 'tw.view.blur': viewCommandHandlers.blur,
+                'tw.state.alignment': stateCommandHandlers.alignment,
             },
             components: {
                 doc: new DocComponent('doc'),

--- a/packages/core/src/tw/view/pointer-observer.ts
+++ b/packages/core/src/tw/view/pointer-observer.ts
@@ -66,6 +66,10 @@ export class PointerObserver implements IPointerObserver {
     }
 
     protected handleMouseDown = (event: MouseEvent) => {
+        const page = this.resolvePage(event);
+        if (page === null) {
+            return;
+        }
         const offset = this.resolveCoordinates(event.clientX, event.clientY);
         if (offset === null) {
             return;
@@ -142,6 +146,17 @@ export class PointerObserver implements IPointerObserver {
                 return cumulatedOffset + pageLayoutNode.convertCoordinatesToOffset(pageX, pageY);
             }
             cumulatedOffset += pageLayoutNode.getSize();
+        }
+        return null;
+    }
+
+    resolvePage(event: MouseEvent) {
+        const path = event.composedPath() as HTMLElement[];
+        for (let element of path) {
+            if (typeof element.getAttribute === "function"
+                && element.getAttribute('data-tw-component') === "page") {
+                return element;
+            }
         }
         return null;
     }

--- a/packages/core/src/tw/view/tree-builder.test.ts
+++ b/packages/core/src/tw/view/tree-builder.test.ts
@@ -2,7 +2,7 @@ import { JSDOM } from 'jsdom';
 import { DocComponent, DocLayoutNode } from '../component/components/doc';
 import { LineLayoutNode, LineViewNode } from '../component/components/line';
 import { PageLayoutNode, PageViewNode } from '../component/components/page';
-import { ParagraphComponent, ParagraphLayoutNode, ParagraphViewNode } from '../component/components/paragraph';
+import { ParagraphComponent, ParagraphLayoutNode, ParagraphViewNode, DEFAULT_PARAGRAPH_STYLE } from '../component/components/paragraph';
 import {
     DEFAULT_TEXT_STYLE,
     TextComponent,
@@ -40,7 +40,7 @@ describe('ViewTreeBuilder', () => {
         docLayoutNode = new DocLayoutNode('doc', 'doc');
         const pageLayoutNode = new PageLayoutNode('page', 816, 1056, 40, 40, 40, 40);
         docLayoutNode.appendChild(pageLayoutNode);
-        const paragraphLayoutNode = new ParagraphLayoutNode('paragraph', '1');
+        const paragraphLayoutNode = new ParagraphLayoutNode('paragraph', '1', DEFAULT_PARAGRAPH_STYLE);
         pageLayoutNode.appendChild(paragraphLayoutNode);
         const lineLayoutNode = new LineLayoutNode('line');
         paragraphLayoutNode.appendChild(lineLayoutNode);


### PR DESCRIPTION
Add text-align and direction change capability to Taleweaver.

- add text-align button in the toolbar
- create `AttributeOperation` for modifying attributes of a single tag
- create `alignment` command to change the block's alignment
- prevent `pointer-observer` from raising invalid mouse events. (In order to reproduce the issue, scroll the page down select more than one paragraph and hit right align button)

# TODO

- [ ] fix the position of the cursor on right-align and center-align paragraphs