### PR TITLE
fix(print): improve Arabic text rendering

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
     "@taleweaver/core": "^0.0.1",
+    "@taleweaver/digital": "^0.0.1",
     "@taleweaver/print": "^0.0.1",
     "@taleweaver/hyphenation-en-us": "0.0.1",
     "@taleweaver/react": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "@taleweaver/core": "^0.0.1",
+        "@taleweaver/digital": "^0.0.1",
         "@taleweaver/hyphenation-en-us": "0.0.1",
         "@taleweaver/print": "^0.0.1",
         "@taleweaver/react": "0.0.1",

--- a/packages/print/src/canvas-renderer.ts
+++ b/packages/print/src/canvas-renderer.ts
@@ -4,6 +4,7 @@ import type { SelectionRect } from "./cursor/selection-geometry";
 import { markStart, markEnd, resolveSpacingPx, clusterSpacing, fromTransformFns, resolveTransformOrigin, physicalBorderSides } from "@taleweaver/core";
 import { buildCssFontString } from "./font-config";
 import { segmentClusters } from "./text-clusters";
+import { needsNativeComplexShaping } from "./complex-script";
 import type { ImageCache } from "./image-cache";
 import { hashPaintInputs } from "./paint-cache";
 import type { PaintCache, Rect, MatchHighlightRectSnapshot, CommentHighlightRectSnapshot, SuggestionHighlightRectSnapshot } from "./paint-cache";
@@ -1358,7 +1359,21 @@ function paintBox(
     // "ltr" (the physical-coordinate contract). `undefined`/even ⇒ LTR (the
     // overwhelmingly common case), painted exactly as before.
     const rtl = box.bidiLevel !== undefined && box.bidiLevel % 2 === 1;
-    if (rtl) {
+    // Native complex-script shaping path (Arabic-family scripts): draw the whole
+    // run so the browser applies contextual forms/ligatures. Keep this gated to
+    // normal spacing; explicit letter/word spacing still needs cluster placement.
+    const useNativeComplexRun =
+      needsNativeComplexShaping(box.text) && letterPx === 0 && wordPx === 0;
+    if (useNativeComplexRun) {
+      if (rtl) {
+        ctx.save();
+        ctx.textAlign = "right";
+        ctx.fillText(box.text, absX + box.width, baselineY);
+        ctx.restore();
+      } else {
+        ctx.fillText(box.text, absX, baselineY);
+      }
+    } else if (rtl) {
       // Place the logically-first cluster at the box's RIGHT edge and walk left.
       // Using the SAME per-cluster advances as the LTR path (so the run still
       // spans exactly [absX, absX + box.width]); only the WITHIN-box placement

--- a/packages/print/src/canvas-shaper.ts
+++ b/packages/print/src/canvas-shaper.ts
@@ -10,14 +10,17 @@ import type {
 import { resolveSpacingPx, clusterSpacing, toBreakOpportunities } from "@taleweaver/core";
 import { buildCssFontString } from "./font-config";
 import { segmentClusters } from "./text-clusters";
+import { needsNativeComplexShaping } from "./complex-script";
 
 /**
  * Canvas-based TextShaper. Default backend bundled with `@taleweaver/print`.
  *
  * Limitations vs a HarfBuzz backend:
- *   - Each UAX #29 grapheme cluster is one cluster (combining marks, surrogate
- *     pairs, ZWJ sequences, regional-indicator flags each form one cluster) with
- *     per-cluster `measureText` metrics — no HarfBuzz shaping / ligature detection.
+ *   - Grapheme segmentation is UAX #29; when complex-script shaping is needed
+ *     (Arabic-family scripts), the backend delegates glyph shaping to the browser
+ *     by measuring the whole run and distributing advances back to clusters. This
+ *     preserves contextual forms but is still an approximation for per-cluster
+ *     carets compared with a real shaping engine.
  *   - Break opportunities come from the conformant UAX #14 line-break
  *     classifier (soft/hard kinds); the `hyphen` kind stays reserved for a
  *     future hyphenation backend.
@@ -79,18 +82,45 @@ export function createCanvasShaper(
     // `normal`-identity contract means default styles add 0 (see text-spacing.ts).
     const letterPx = resolveSpacingPx(style.letterSpacing);
     const wordPx = resolveSpacingPx(style.wordSpacing);
-    // Segment via the shared helper so the renderer (which paints each cluster
-    // at the matching cumulative advance, #330) can never diverge from how the
-    // shaper measured. v1 clusters are single code units.
+    // Segment via the shared helper so shaper and renderer stay in lockstep.
     let start = 0;
-    for (const c of segmentClusters(text)) {
+    const segmented = segmentClusters(text);
+    // Native complex shaping path (Arabic-family scripts): when spacing is
+    // `normal`, renderer paints this run in one fillText call. To keep
+    // caret/hit-test aligned with that painted run, derive each cluster advance
+    // from prefix deltas of the NATIVE shaped width:
+    //   adv(i) = width(text[0..i]) - width(text[0..i-1]).
+    // This captures contextual joining effects much better than proportional
+    // redistribution of isolated-cluster widths.
+    const useNativeComplexRun =
+      needsNativeComplexShaping(text) && letterPx === 0 && wordPx === 0;
+    const nativeClusterAdvances: number[] = [];
+    if (useNativeComplexRun) {
+      let prefix = "";
+      let prev = 0;
+      for (const c of segmented) {
+        prefix += c;
+        const current = ctx.measureText(prefix).width;
+        nativeClusterAdvances.push(Math.max(0, current - prev));
+        prev = current;
+      }
+    }
+
+    for (let i = 0; i < segmented.length; i++) {
+      const c = segmented[i];
+      if (c === undefined) continue;
       // U+00AD SOFT HYPHEN is a zero-advance format char (Cf): it renders nothing
       // and adds no width unless it is the chosen line-end break (where the IFC
       // shapes a "-" glyph separately). `ctx.measureText("­")` is browser/
       // font-dependent (often the width of a rendered hyphen), so we force 0 here
       // to match real shapers (HarfBuzz zero-advances default-ignorable Cf chars)
       // and keep word widths invariant to embedded soft hyphens (hyphenation).
-      const w = c === "­" ? 0 : ctx.measureText(c).width + clusterSpacing(c, letterPx, wordPx);
+      const raw = c === "\u00AD"
+        ? 0
+        : useNativeComplexRun
+          ? (nativeClusterAdvances[i] ?? 0)
+          : ctx.measureText(c).width;
+      const w = raw + clusterSpacing(c, letterPx, wordPx);
       clusters.push({
         start,
         end: start + c.length,

--- a/packages/print/src/cluster-paint.test.ts
+++ b/packages/print/src/cluster-paint.test.ts
@@ -258,6 +258,13 @@ describe("#330 cluster-positioned painting", () => {
     expect(ctx._fills.length).toBe(0);
   });
 
+  it("complex-script runs (Arabic) paint as one native-shaped fillText call", () => {
+    const box = makeTextRun({ text: "عربي", x: 12 });
+    paint(ctx, box);
+    expect(ctx._fills.length).toBe(1);
+    expect(nth(ctx._fills, 0, "fill")).toMatchObject({ text: "عربي", x: 12 });
+  });
+
   it("paints whitespace clusters (spaces have width)", () => {
     const box = makeTextRun({ text: "a b", x: 0 });
     paint(ctx, box);

--- a/packages/print/src/complex-script.ts
+++ b/packages/print/src/complex-script.ts
@@ -1,0 +1,30 @@
+/**
+ * Detect scripts that need contextual shaping (Arabic and related scripts).
+ *
+ * The canvas backend can delegate shaping to the browser by drawing/measuring
+ * the WHOLE run once. That path is critical for scripts whose glyph forms
+ * depend on neighbors (initial/medial/final forms, lam-alef ligatures, etc.).
+ */
+const COMPLEX_SCRIPT_RE: RegExp = (() => {
+  try {
+    // Prefer Unicode property escapes when available.
+    return new RegExp(
+      [
+        "\\p{Script=Arabic}",
+        "\\p{Script=Syriac}",
+        "\\p{Script=Thaana}",
+        "\\p{Script=Nko}",
+        "\\p{Script=Mandaic}",
+      ].join("|"),
+      "u",
+    );
+  } catch {
+    // Fallback ranges for older engines.
+    return /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
+  }
+})();
+
+/** True when text should be shaped as a single run to preserve contextual forms. */
+export function needsNativeComplexShaping(text: string): boolean {
+  return COMPLEX_SCRIPT_RE.test(text);
+}


### PR DESCRIPTION
- Use native canvas shaping for complex scripts
- Add complex script detection
- Improve cluster advance calculation using prefix widths
- Fix caret positioning for Arabic text
- Add regression tests for Arabic rendering